### PR TITLE
Fixed libcurlpp-dev dependency

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,10 +22,8 @@ Installing dependencies:
 
 ```bash
 sudo apt update
-sudo apt dist-upgrade
 rosdep update
-git -C src clone --branch galactic https://github.com/gbartyzel/ros2_net_ft_driver.git
-sudo apt install -y libasio-dev libcurlpp-dev
+git -C src clone --branch humble https://github.com/gbartyzel/ros2_net_ft_driver.git
 rosdep install --ignore-src --from-paths src -y -r --rosdistro $ROS_DISTRO
 ```
 

--- a/net_ft_driver/package.xml
+++ b/net_ft_driver/package.xml
@@ -15,6 +15,7 @@
 
   <depend>asio</depend>
   <depend>asio_cmake_module</depend>
+  <depend>curlpp-dev</depend>
   <depend>hardware_interface</depend>
   <depend>pluginlib</depend>
   <depend>rclcpp</depend>


### PR DESCRIPTION
Added missing `curlpp-dev` dependency in the `net_fr_driver` package. This resolves the problem with manual installation of this library via `sudo apt install -y libasio-dev libcurlpp-dev`.

### Related PRs:
- https://github.com/AGH-CEAI/aegis_ros/pull/7
- https://github.com/AGH-CEAI/aegis_docker/pull/1

---
Clickup task: [8695yc6zh](https://app.clickup.com/t/8695yc6zh)
